### PR TITLE
Change output generation paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-trigger-action",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ebeloded/svelte-trigger-action"
@@ -19,7 +19,7 @@
   "module": "./dist/lib.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
-    "types": "dist/runtime.d.ts",
+    "types": "./dist/types/index.d.ts",
     ".": {
       "import": "./dist/lib.js",
       "require": "./dist/lib.cjs"

--- a/package.json
+++ b/package.json
@@ -15,14 +15,13 @@
     "serve": "vite preview"
   },
   "type": "module",
-  "main": "./dist/lib.cjs",
-  "module": "./dist/lib.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "types": "./dist/types/index.d.ts",
     ".": {
-      "import": "./dist/lib.js",
-      "require": "./dist/lib.cjs"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitReturns": true,
     "emitDeclarationOnly": true,
     "skipLibCheck": true,
-    "outDir": "dist/types"
+    "outDir": ".dist/"
   },
   "include": ["./src/lib"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,8 +12,8 @@ export default defineConfig({
       name,
       fileName: (format) =>
         ({
-          cjs: 'lib.cjs',
-          es: 'lib.js',
+          cjs: 'index.cjs',
+          es: 'index.js',
         }[format]),
     },
   },


### PR DESCRIPTION
Changes:
- Types will be alongside generated outputs, not in a separate folder
- All generated files will be named `index.*`